### PR TITLE
Release 1.2.0

### DIFF
--- a/bin/offenbach
+++ b/bin/offenbach
@@ -16,8 +16,8 @@
 
 offenbach_name=Offenbach
 offenbach_url=https://github.com/yannoff/offenbach
-offenbach_build_version=1.1.1
-offenbach_build_date=2020-11-07T20:39:05+01:00
+offenbach_build_version=1.2.0
+offenbach_build_date=2020-11-14T10:14:49+01:00
 
 yamltools=yamltools
 composer=composer
@@ -30,6 +30,7 @@ composer=composer
 _debug(){
     [ -n "${verbosity}" ] || return 0
     local msg=$1
+    [ -n "${msg}" ] || return 0
     shift 1
     set -- "[offenbach] ${msg}\n" "$@"
     printf "$@" >&2
@@ -56,6 +57,19 @@ _exec(){
 _copy(){
     local src=$1 dest=$2
     [ -f ${src} ] && _exec "cp -v ${src} ${dest}"
+    return $?
+}
+
+#
+# Move source file to destination file
+# @param $source The source file
+# @param $target The destination file
+#
+# @todo Return error code and display error message if $source does not exist
+#
+_move(){
+    local src=$1 dest=$2
+    [ -f ${src} ] && _exec "mv -v ${src} ${dest}"
     return $?
 }
 
@@ -93,12 +107,13 @@ _restore(){
 }
 
 #
-# Remove the given file
+# Remove the given file, if it exists
 # @param $file Path to the file to be removed
 #
 _remove(){
     local file=$1
-    _exec "rm -fv ${file}"
+    [ -f ${file} ] && _exec "rm -fv ${file}"
+    return $?
 }
 
 #
@@ -120,30 +135,6 @@ EOS
 }
 
 
-# Parse command line arguments,
-# some commands don't need to load composer.json & composer.lock files
-for arg; do
-    case "${arg}" in
-        -v|-vv|-vvv)
-            verbosity=${arg};
-            ;;
-        about)
-            printf "\033[01m%s\033[00m - \033[01m%s\033[00m\n" ${offenbach_name} "Overlay script providing support for composer.yaml files"
-            ${composer} "$@"
-            exit $?
-            ;;
-        --version|list)
-            printf "\033[01m%s\033[00m version \033[01m%s\033[00m %s\n" ${offenbach_name} ${offenbach_build_version} "${offenbach_build_date/T/ }"
-            ${composer} "$@"
-            exit $?
-            ;;
-        --help|help|search|selfupdate|self-update)
-            ${composer} "$@"
-            exit $?
-            ;;
-    esac
-done
-
 # Fetch alternative composer.json name set from environment, if any
 environment_composer=`printenv COMPOSER`
 
@@ -160,34 +151,77 @@ lock_file=composer-lock.yaml
 default_composer=composer.json
 default_lockfile=composer.lock
 
+
+# Parse command line arguments,
+# some commands don't need to load composer.json & composer.lock files
+for arg; do
+    case "${arg}" in
+        -v|-vv|-vvv)
+            verbosity=${arg};
+            ;;
+        about)
+            printf "\033[01m%s\033[00m - \033[01m%s\033[00m\n" ${offenbach_name} "Overlay script providing support for composer.yaml files"
+            ${composer} "$@"
+            exit $?
+            ;;
+        # Temporarily disabling the create-project command, which fails
+        # @see https://github.com/yannoff/offenbach/issues/9
+        create-project)
+            printf "Sorry, the \033[01m%s\033[00m command is not supported yet. Aborting.\n" "${arg}"
+            exit 1
+            ;;
+        --version|list)
+            printf "\033[01m%s\033[00m build: \033[01m%s\033[00m %s\n" ${offenbach_name} ${offenbach_build_version} "${offenbach_build_date/T/ }"
+            ${composer} "$@"
+            exit $?
+            ;;
+        --help|help|search|selfupdate|self-update)
+            ${composer} "$@"
+            exit $?
+            ;;
+    esac
+done
+
 # Assess the situation and decide what to do:
 # - if a composer.yaml file is found, offenbach has been run at least once on the project
 # => convert both dependency and lock (if exists) files to their temporary JSON alter ego
 # - if an alternative filename is set via COMPOSER env variable and the file exists
 # OR
 # - if a composer.json file is found and there was no composer.yaml, assume offenbach is run for the first time
-# => copy dependency and lock file to their temporary versions
-first_run=yes
+# => move dependency and lock file to their temporary counterparts
 if [ -f "${yaml_file}" ]
 then
-    _debug "Found a \033[01m%s\033[00m file. Converting to JSON..." "${yaml_file}"
     first_run=
+
+    _debug "Found a \033[01m%s\033[00m file. Converting to JSON..." "${yaml_file}"
+    # Keep a copy of the original composer.yaml, for later comments restore process
     _copy ${yaml_file} ${yaml_orig}
+    # Create JSON temporary files from YAML original ones
     _yaml2json ${yaml_file} ${temporary_composer}
     _yaml2json ${lock_file} ${temporary_lockfile}
-elif [ -n "${environment_composer}" -a -f "${environment_composer}" ]
-then
-    _debug "Found a COMPOSER env variable set... Fetching content"
-    environment_lockfile=`basename ${environment_composer} .json`.lock
-    _copy ${environment_composer} ${temporary_composer}
-    _copy ${environment_lockfile} ${temporary_lockfile}
-elif [ -f "${default_composer}" ]
-then
-    _debug "Found a \033[01m%s\033[00m file. Copying to: \033[01m%s\033[00m." "${default_composer}" "${temporary_composer}"
-    _copy ${default_composer} ${temporary_composer}
-    _copy ${default_lockfile} ${temporary_lockfile}
 else
-    _debug "No \033[01m%s\033[00m nor \033[01m%s\033[00m file found here." "${default_composer}" "${yaml_file}"
+    first_run=yes
+
+    if [ -n "${environment_composer}" ]
+    then
+        _debug "Found a \033[01mCOMPOSER\033[00m env variable set (value: \033[01m%s\033[00m)" "${environment_composer}"
+        environment_lockfile=`basename ${environment_composer} .json`.lock
+        initial_composer=${environment_composer}
+        initial_lockfile=${environment_lockfile}
+    else
+        initial_composer=${default_composer}
+        initial_lockfile=${default_lockfile}
+    fi
+
+    if [ ! -f "${initial_composer}" ]
+    then
+        _debug "No \033[01m%s\033[00m nor \033[01m%s\033[00m file found here." "${initial_composer}" "${yaml_file}"
+    else
+        _debug "Found a \033[01m%s\033[00m file. Copying to: \033[01m%s\033[00m." "${initial_composer}" "${temporary_composer}"
+        # Rename initial composer files to their temporary counterparts
+        _move ${initial_composer} ${temporary_composer}
+        _move ${initial_lockfile} ${temporary_lockfile}
+    fi
 fi
 
 # Execute composer in a secluded environment, setting COMPOSER env variable to the temporary JSON filename


### PR DESCRIPTION
**Runtime**
- 955f962 Reword `--version` option output
- ae3df1c Remove initial files after migrating
- b623977 Temporarily disable non working `create-project` command (see #9) 
- c916d25 Move filenames block above args parsing
- e074bc7 Rework main process logic

**Install**
- d9ebc08 Exclude dev files from release archives
- 5fc5ff3 Builder: support `-dev` or `-rc` suffix for versions