### PR TITLE
[runtime] Refactor special commands section

### DIFF
--- a/src/offenbach
+++ b/src/offenbach
@@ -135,8 +135,7 @@ EOS
 }
 
 # Parse command line arguments.
-# Some commands don't need to load composer.json & composer.lock files
-# On the other hand, certain options need to be processed specifically
+# Certain options need to be processed specifically
 args=()
 
 while [ $# -gt 0 ]
@@ -154,26 +153,6 @@ do
             ;;
         --working-dir=*)
             cwd=${arg##*=}
-            ;;
-        about)
-            printf "\033[01m%s\033[00m - \033[01m%s\033[00m\n" ${offenbach_name} "Overlay script providing support for composer.yaml files"
-            ${composer} "$@"
-            exit $?
-            ;;
-        # Temporarily disabling the create-project command, which fails
-        # @see https://github.com/yannoff/offenbach/issues/9
-        create-project)
-            printf "Sorry, the \033[01m%s\033[00m command is not supported yet. Aborting.\n" "${arg}"
-            exit 1
-            ;;
-        --version|list)
-            printf "\033[01m%s\033[00m build: \033[01m%s\033[00m %s\n" ${offenbach_name} ${offenbach_build_version} "${offenbach_build_date/T/ }"
-            ${composer} "$@"
-            exit $?
-            ;;
-        --help|help|search|selfupdate|self-update)
-            ${composer} "$@"
-            exit $?
             ;;
         *)
             args+=(${arg})
@@ -230,6 +209,30 @@ def_lockfile=${base}.lock
 
 _debug "Using \033[01m%s\033[00m for the dependency file name" ${yaml_file}
 
+# Process special commands
+# Some commands don't need to load composer.json & composer.lock files
+case $1 in
+        about)
+            printf "\033[01m%s\033[00m - \033[01m%s\033[00m\n" ${offenbach_name} "Overlay script providing support for composer.yaml files"
+            ${composer} "$@"
+            exit $?
+            ;;
+        # Temporarily disabling the create-project command, which fails
+        # @see https://github.com/yannoff/offenbach/issues/9
+        create-project)
+            printf "Sorry, the \033[01m%s\033[00m command is not supported yet. Aborting.\n" "${arg}"
+            exit 1
+            ;;
+        --version|list)
+            printf "\033[01m%s\033[00m build: \033[01m%s\033[00m %s\n" ${offenbach_name} ${offenbach_build_version} "${offenbach_build_date/T/ }"
+            ${composer} "$@"
+            exit $?
+            ;;
+        --help|help|search|selfupdate|self-update)
+            ${composer} "$@"
+            exit $?
+            ;;
+esac
 
 # Assess the situation and decide what to do:
 # - if the YAML file is found, offenbach has been run at least once on the project


### PR DESCRIPTION
Move special command handling logic:
- out of the command-line argument handling block (improves `-v` or `-d` options support)
- after composer file names are defined (road to `create-project` command implementation)